### PR TITLE
 Enable Github Releases integration w/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ os:
 
 language: go
 
-addons:
-    artifacts:
-        debug: true
-        paths:
-        - $GOPATH/bin
-
 dist: trusty
 
 go:
@@ -38,9 +32,10 @@ install:
     - dep ensure
 
 deploy:
+    provider: releases
+    file: honeykaf
+    skip_cleanup: true
     on:
+      repo: cargurus/honeykaf
       branch: master
-      condition: false # change when we figure out where to drop artifacts
-
-addons:
-  artifacts: false
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,38 @@ language: go
 dist: trusty
 
 go:
-    - 1.9
+  - 1.9
 
 env:
-    - DEP_VERSION="0.4.1"
+  - DEP_VERSION="0.4.1"
 
 script:
-    - set -e
+  - set -e
 # Run tests
-    - go test github.com/cargurus/honeykaf/...
+  - go test github.com/cargurus/honeykaf/...
 # Build binary and packages
-    - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/cargurus/honeykaf/...
+  - go install -ldflags "-X main.BuildID=1.${TRAVIS_BUILD_NUMBER}" github.com/cargurus/honeykaf/...
 
 before_install:
 # Download the binary to bin folder in $GOPATH
-    - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
 # Make the binary executable
-    - chmod +x $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
 # Install fpm for deb/rpm package building
-    - sudo apt-get -qq update
-    - sudo apt-get install -y build-essential rpm
+  - sudo apt-get -qq update
+  - sudo apt-get install -y build-essential rpm
 
 install:
-    - true # HACK: fixes travis-CI lack of support for vendor/ + godeps
-    - dep ensure
+  - true # HACK: fixes travis-CI lack of support for vendor/ + godeps
+  - dep ensure
 
 deploy:
-    provider: releases
-    file: honeykaf
-    skip_cleanup: true
-    on:
-      repo: cargurus/honeykaf
-      branch: master
-      tags: true
+  provider: releases
+  api_key:
+    secure: ${RELEASES_API_KEY_SECURE}
+  file: honeykaf
+  skip_cleanup: true
+  on:
+    repo: cargurus/honeykaf
+    branch: master
+    tags: true


### PR DESCRIPTION
We build artifacts for committed tags to master branch that have the semantic tag pattern. I’ve limited builds to this repo only to avoid grief for/from forks.

Also, we now encrypt GH release API key with Travis repo keypair. I created a Github access token using `travis setup releases` command, then made the `secure` value into a Travis environment variable. This prevents us leaking a token that grants repo access to someone with access to build logs.

`travis lint` is happy with this.